### PR TITLE
Fix import warning

### DIFF
--- a/src/Dev/Runner.hs
+++ b/src/Dev/Runner.hs
@@ -15,7 +15,7 @@ computation.
 module Dev.Runner (update, shutdown) where
 
 import Control.Exception (finally)
-import Control.Monad ((>=>), forever)
+import Control.Monad ((>=>))
 import Control.Concurrent
 import Data.IORef
 import Foreign.Store


### PR DESCRIPTION
`stack build --pedantic` was failing with

```
src/Dev/Runner.hs:18:1: Warning:
    The import of ‘forever’ from module ‘Control.Monad’ is redundant
```

Is there a way to remove the double parenthesis?
